### PR TITLE
Lazy loading some plugins

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -15,14 +15,6 @@ require "plugins.compe-config"
 require "lsp-config"
 -- general configurations
 require "options"
--- lualine configuration
-require "plugins.statusline"
--- nvim-bufferline.lua configuration
-require "plugins.top-bufferline"
--- fuzzy finder configuration
-require "plugins.telescope-config"
--- Git changes(showing in line number) configuration
-require "plugins.gitsigns-config"
 -- configuration to help you remember keybindings
 require "plugins.which-key-config"
 -- nvim tree

--- a/lua/pluginList.lua
+++ b/lua/pluginList.lua
@@ -8,28 +8,48 @@ require("packer").startup(
 
     use "glepnir/lspsaga.nvim"
     use "kabouzeid/nvim-lspinstall"
-    use "nvim-treesitter/nvim-treesitter"
+    use {
+      "nvim-treesitter/nvim-treesitter",
+      event = 'BufRead',
+      run = ':TSUpdate'
+    }
     use "hrsh7th/nvim-compe"
     use "neovim/nvim-lspconfig"
     use "folke/tokyonight.nvim"
     use {
       "hoob3rt/lualine.nvim",
+      event = "BufWinEnter",
+      config = function()
+        require "plugins.statusline"
+      end,
       requires = {"kyazdani42/nvim-web-devicons", opt = true}
     }
 
     use {
       "nvim-telescope/telescope.nvim",
+      cmd = "Telescope",
+      config = function()
+        require "plugins.telescope-config"
+      end,
       requires = {{"nvim-lua/popup.nvim"}, {"nvim-lua/plenary.nvim"}}
     }
 
     use {
       "akinsho/nvim-bufferline.lua",
+      event = "BufWinEnter",
+      config = function()
+        require "plugins.top-bufferline"
+      end,
       requires = "kyazdani42/nvim-web-devicons"
     }
 
     use "jiangmiao/auto-pairs"
     use {
       "folke/trouble.nvim",
+      cmd = "TroubleToggle",
+      config = function()
+        require("trouble").setup()
+      end,
       requires = "kyazdani42/nvim-web-devicons"
     }
 
@@ -49,6 +69,10 @@ require("packer").startup(
 
     use {
       "lewis6991/gitsigns.nvim",
+      event = "BufReadPre",
+      config = function()
+        require "plugins.gitsigns-config"
+      end,
       requires = {
         "nvim-lua/plenary.nvim"
       }
@@ -61,6 +85,7 @@ require("packer").startup(
     use "yuttie/comfortable-motion.vim"
     use {
       "mhartington/formatter.nvim",
+      cmd = "Format",
       opt = true
     }
     use {

--- a/lua/plugins/misc.lua
+++ b/lua/plugins/misc.lua
@@ -1,2 +1,1 @@
 require("lspkind").init()
-require("trouble").setup()


### PR DESCRIPTION
Plugins that are being lazy-loaded:

- Treesitter (when you actually load a file, not just an empty buffer)
- Telescope (when you run Telescope either through a keybind or a command)
- Trouble (same as with Telescope)
- Gitsigns (same as with Treesitter)
- Formatter (same as with Telescope)
- Lualine, Bufferline (when the screen draws or the first time)

You have to run `nvim -c "lua require 'pluginList' require('packer').sync()"` to update your plugins, since these ones are now being lazy loaded, Packer has to recompile them.