### PR TITLE
Fix for nvim-Tree plugin error "Not an editor command: NvimTreeToggle"

### DIFF
--- a/lua/pluginList.lua
+++ b/lua/pluginList.lua
@@ -53,7 +53,11 @@ require("packer").startup(function(use)
   use({
     "NvChad/nvim-base16.lua",
   })
-  use({ "kyazdani42/nvim-tree.lua", opt = true, cmd = { "NvimTreeToggle" } })
+  use({
+    'kyazdani42/nvim-tree.lua',
+    requires = 'kyazdani42/nvim-web-devicons',
+    config = function() require'nvim-tree'.setup {} end
+  })
   use("glepnir/lspsaga.nvim")
   use("kabouzeid/nvim-lspinstall")
   use("nvim-treesitter/nvim-treesitter")


### PR DESCRIPTION
Nvim-Tree recently changed their installation method in the latest update. I changed the code in PluginList.lua to reflect these new changes and resolve the error. 